### PR TITLE
Fix reprocess delete request handler to run processing logic

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -319,7 +319,6 @@ exports.reprocessDeleteRequest = functions
       res.status(400).json({ error: "Missing docId" });
       return;
     }
-  });
 
     try {
       const docRef = admin.firestore().collection("delete_requests").doc(docId);


### PR DESCRIPTION
## Summary
- fix the Cloud Function handler for reprocessDeleteRequest so that the Firestore lookup and email resend logic run inside the request scope

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690ab0eab334832b82b60e7192a4f210